### PR TITLE
Upgrade bearer token grabber

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To get your bearer token
  - Go to the "console" tab
  - paste this code into the console:
 ```js
-console.log(`; ${document.cookie}`.split(`; bearer_token=`).pop().split(';').shift())
+console.log(document.cookie.match(/bearer_token=([^;]+)/)?.[1] ?? 'There is no bearer token in your cookies, make sure you are on minecraft.net and that you are logged into your account.')
 ```
 Now you have your bearer token!
 


### PR DESCRIPTION
Breakdown of new logic:

``/bearer_token=``
beginning of the bearer token in `document.cookie` (looks something like `adtrack=123;cool_guy=you;bearer_token=bearerhere`)

``([^;]+)/``
groups all characters starting after `bearer_token=` one by one, stopping at the first semicolon it sees

``?.[1]``
Selects the grouping mentioned above with optional chaining, meaning that if the bearer token is not found, there is no error, instead returning undefined.

`` ?? 'There is no bearer token in your cookies, make sure you are on minecraft.net and that you are logged into your account.'``
If the above logic returns undefined, the nullish coalescing operator will show the above message.  